### PR TITLE
기사 스크랩 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.1",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.4.6"
       },
       "devDependencies": {
         "@types/react-router": "^5.1.20",
@@ -16932,6 +16933,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17965,6 +17974,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.4.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Bottom/index.tsx
+++ b/src/components/Bottom/index.tsx
@@ -1,34 +1,29 @@
 import { S } from "./style";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { ReactComponent as HomeIcon } from "../../asset/icon/home.svg";
 import { ReactComponent as ScrapIcon } from "../../asset/icon/scrap.svg";
 import { useState } from "react";
 
 export default function Bottom() {
-  const [currentTab, setCurrentTab] = useState("home");
+  const location = useLocation();
+  const isHome = location.pathname === "/";
+  const isScrap = location.pathname === "/scrap";
 
   const navigate = useNavigate();
-  const movePage = (name: string, path: string): void => {
+  const movePage = (path: string): void => {
     navigate(path);
-    setCurrentTab(name);
   };
 
   return (
     <S.Container>
-      <S.Btn
-        onClick={() => movePage("home", "/")}
-        $currentTab={currentTab === "home"}
-      >
-        <HomeIcon fill={currentTab === "home" ? "#FFFFFF" : "#6D6D6D"} />홈
+      <S.Btn onClick={() => movePage("/")} $currentTab={isHome}>
+        <HomeIcon fill={isHome ? "#FFFFFF" : "#6D6D6D"} />홈
       </S.Btn>
-      <S.Btn
-        onClick={() => movePage("scrap", "/scrap")}
-        $currentTab={currentTab === "scrap"}
-      >
+      <S.Btn onClick={() => movePage("/scrap")} $currentTab={isScrap}>
         <ScrapIcon
           width="24"
           height="24"
-          stroke={currentTab === "scrap" ? "#FFFFFF" : "#6D6D6D"}
+          stroke={isScrap ? "#FFFFFF" : "#6D6D6D"}
         />
         스크랩
       </S.Btn>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,14 +1,31 @@
 import { S } from "./style";
 import { ReactComponent as StarIcon } from "../../asset/icon/star.svg";
 import { ReactComponent as CheckedStarIcon } from "../../asset/icon/checkedStar.svg";
+import { useEffect, useState } from "react";
+import { useArticleStore } from "store/articles";
 
 const daysOfWeek = ["일", "월", "화", "수", "목", "금", "토"];
-interface cardDataProps {
-  [key: string]: string | object | number;
+interface ArticlesData {
+  data: {
+    _id: string;
+    pub_date: string;
+    headline: {
+      main: string;
+    };
+    news_desk: string;
+    byline: {
+      person: [{ firstname: string }];
+    };
+    like: boolean;
+  };
 }
 
-export default function Card({ data }: cardDataProps) {
-  const date = new Date(data.pub_date);
+export default function Card({ data }: ArticlesData) {
+  const { _id, pub_date, headline, news_desk, byline, like } = { ...data };
+  const [isSaved, setIsSaved] = useState(false);
+  const { addArticle, removeArticle } = useArticleStore();
+
+  const date = new Date(pub_date);
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
@@ -17,17 +34,38 @@ export default function Card({ data }: cardDataProps) {
     day < 10 ? "0" + day : day
   } (${dayOfWeek})`;
 
+  useEffect(() => {
+    if (like) {
+      setIsSaved(like);
+    }
+  }, []);
+
+  const saveArticles = () => {
+    setIsSaved(true);
+    addArticle({ _id, pub_date, headline, news_desk, byline, like: true });
+    // saveArticle({ _id, pub_date, headline, news_desk, byline, like: true });
+  };
+
+  const removeArticles = (id: string) => {
+    // removeArticle(id);
+    removeArticle(id);
+    setIsSaved(false);
+  };
+
   return (
     <S.Container>
       <S.Top>
-        <S.Title>{data.headline.main}</S.Title>
-        <StarIcon fill="#6D6D6D" />
-        <CheckedStarIcon fill="#FFB800" />
+        <S.Title>{headline.main}</S.Title>
+        {isSaved ? (
+          <CheckedStarIcon onClick={() => removeArticles(_id)} fill="#FFB800" />
+        ) : (
+          <StarIcon onClick={() => saveArticles()} fill="#6D6D6D" />
+        )}
       </S.Top>
       <S.Bottom>
         <S.NameContainer>
-          <S.NameData>{data.news_desk}</S.NameData>
-          {data.byline.person.map((name, idx) => {
+          <S.NameData>{news_desk}</S.NameData>
+          {byline.person.map((name, idx) => {
             return <S.NameData key={idx}>{name.firstname} 기자</S.NameData>;
           })}
         </S.NameContainer>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -43,11 +43,9 @@ export default function Card({ data }: ArticlesData) {
   const saveArticles = () => {
     setIsSaved(true);
     addArticle({ _id, pub_date, headline, news_desk, byline, like: true });
-    // saveArticle({ _id, pub_date, headline, news_desk, byline, like: true });
   };
 
   const removeArticles = (id: string) => {
-    // removeArticle(id);
     removeArticle(id);
     setIsSaved(false);
   };

--- a/src/modules/function.ts
+++ b/src/modules/function.ts
@@ -1,0 +1,9 @@
+export const removeArticles = (id: string) => {
+  const preList = JSON.parse(localStorage.getItem("articleList"));
+  const newList = preList.filter((e: any) => e._id !== id);
+  localStorage.setItem("articleList", JSON.stringify([...newList]));
+
+  const preIdList = JSON.parse(localStorage.getItem("idList"));
+  const newIdList = preIdList.filter((e: any) => e !== id);
+  localStorage.setItem("idList", JSON.stringify([...newIdList]));
+};

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -3,7 +3,6 @@ import { S } from "./style";
 import axios from "axios";
 import { useEffect, useRef, useState } from "react";
 import Card from "../../components/Card";
-import { removeArticles } from "modules/function";
 import { useArticleStore } from "store/articles";
 
 interface ArticlesData {
@@ -21,7 +20,7 @@ export default function Main() {
   const [loading, setLoading] = useState(false);
   const loaderRef = useRef<HTMLDivElement>(null);
   const observer = useRef<IntersectionObserver | null>(null);
-
+  const { idList } = useArticleStore();
   const fetchData = async (pageNumber: number) => {
     setLoading(true);
     try {
@@ -30,8 +29,6 @@ export default function Main() {
       );
       const newData: ArticlesData[] = response.data?.response?.docs || [];
 
-      const idList = JSON.parse(localStorage.getItem("articleList"));
-      // const idList.state.articleList);
       const UpdateData = newData.map((item) => {
         const isScraped = idList?.includes(item._id);
         return { ...item, like: isScraped };
@@ -51,22 +48,6 @@ export default function Main() {
       setLoading(true);
     }
   };
-  // const saveArticle = (item: object) => {
-  //   let preArray: any[] = [];
-  //   let preIdList: any[] = [];
-
-  //   if (localStorage.getItem("articleList")) {
-  //     preArray = JSON.parse(localStorage.getItem("articleList"));
-  //   }
-  //   const newArray = [...preArray, item];
-  //   localStorage.setItem("articleList", JSON.stringify(newArray));
-
-  //   if (localStorage.getItem("idList")) {
-  //     preIdList = JSON.parse(localStorage.getItem("idList"));
-  //   }
-  //   const newIdList = [...preIdList, item._id];
-  //   localStorage.setItem("idList", JSON.stringify(newIdList));
-  // };
 
   useEffect(() => {
     const options = {
@@ -97,14 +78,7 @@ export default function Main() {
   return (
     <S.Container>
       {articleData.map((data) => {
-        return (
-          <Card
-            key={data._id}
-            data={data}
-            // saveArticle={saveArticle}
-            removeArticle={removeArticles}
-          />
-        );
+        return <Card key={data._id} data={data} />;
       })}
       {loading && <p>loading</p>}
       <div

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -3,13 +3,20 @@ import { S } from "./style";
 import axios from "axios";
 import { useEffect, useRef, useState } from "react";
 import Card from "../../components/Card";
+import { removeArticles } from "modules/function";
+import { useArticleStore } from "store/articles";
 
-type Articles = {
-  [key: string]: string;
-};
+interface ArticlesData {
+  _id: string;
+  pub_date: string;
+  headline: object;
+  news_desk: string;
+  byline: object;
+  like: boolean;
+}
 
 export default function Main() {
-  const [articleData, setArticleData] = useState<Articles[]>([]);
+  const [articleData, setArticleData] = useState<ArticlesData[]>([]);
   const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(false);
   const loaderRef = useRef<HTMLDivElement>(null);
@@ -21,8 +28,15 @@ export default function Main() {
       const response = await axios.get(
         `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=election&api-key=8MeO1rSj1FcMC9n8kbDBTUtw0EgduciL&page=${pageNumber}`
       );
-      const newData: Articles[] = response.data?.response?.docs || [];
-      setArticleData((prevData) => [...prevData, ...newData]);
+      const newData: ArticlesData[] = response.data?.response?.docs || [];
+
+      const idList = JSON.parse(localStorage.getItem("articleList"));
+      // const idList.state.articleList);
+      const UpdateData = newData.map((item) => {
+        const isScraped = idList?.includes(item._id);
+        return { ...item, like: isScraped };
+      });
+      await setArticleData((prevData) => [...prevData, ...UpdateData]);
       setPage((prevPage) => prevPage + 1);
     } catch (error) {
       console.error("Error fetching data:", error);
@@ -37,6 +51,22 @@ export default function Main() {
       setLoading(true);
     }
   };
+  // const saveArticle = (item: object) => {
+  //   let preArray: any[] = [];
+  //   let preIdList: any[] = [];
+
+  //   if (localStorage.getItem("articleList")) {
+  //     preArray = JSON.parse(localStorage.getItem("articleList"));
+  //   }
+  //   const newArray = [...preArray, item];
+  //   localStorage.setItem("articleList", JSON.stringify(newArray));
+
+  //   if (localStorage.getItem("idList")) {
+  //     preIdList = JSON.parse(localStorage.getItem("idList"));
+  //   }
+  //   const newIdList = [...preIdList, item._id];
+  //   localStorage.setItem("idList", JSON.stringify(newIdList));
+  // };
 
   useEffect(() => {
     const options = {
@@ -67,7 +97,14 @@ export default function Main() {
   return (
     <S.Container>
       {articleData.map((data) => {
-        return <Card key={data._id} data={data} />;
+        return (
+          <Card
+            key={data._id}
+            data={data}
+            // saveArticle={saveArticle}
+            removeArticle={removeArticles}
+          />
+        );
       })}
       {loading && <p>loading</p>}
       <div

--- a/src/pages/Scrap/index.tsx
+++ b/src/pages/Scrap/index.tsx
@@ -1,39 +1,23 @@
 import { S } from "./style";
 //
-import axios from "axios";
-import { useEffect, useState } from "react";
 import Card from "../../components/Card";
 import Nothing from "./Nothing";
 
-type Articles = {
-  [key: string]: string;
-};
+import { removeArticles } from "modules/function";
+import { useArticleStore } from "store/articles";
 
 export default function Scrap() {
-  const [articleData, setArticleData] = useState<Articles[]>([]);
+  // let articles = JSON.parse(localStorage.getItem("articleList"));
+  const { articleList } = useArticleStore();
 
-  useEffect(() => {
-    axios
-      .get(
-        `https://api.nytimes.com/svc/search/v2/articlesearch.json?q=election&api-key=8MeO1rSj1FcMC9n8kbDBTUtw0EgduciL`
-      )
-      .then((res) => {
-        if (res.status === 200) {
-          setArticleData(res.data.response.docs);
-        } else if (res.status === 400) {
-          return null;
-        }
-      })
-      .catch((res) => {
-        console.log(res);
-      });
-  }, []);
+  const isEmpty = articleList.length === 0;
 
   return (
-    <S.Container $isEmpty={articleData.length === 0}>
-      {articleData.length > 0 ? (
-        articleData.map((data) => {
-          return <Card key={data._id} data={data} />;
+    <S.Container $isEmpty={isEmpty}>
+      {!isEmpty ? (
+        articleList?.map((data) => {
+          console.log(data.content);
+          return <Card key={data.content._id} data={data.content} />;
         })
       ) : (
         <Nothing />

--- a/src/pages/Scrap/index.tsx
+++ b/src/pages/Scrap/index.tsx
@@ -2,21 +2,16 @@ import { S } from "./style";
 //
 import Card from "../../components/Card";
 import Nothing from "./Nothing";
-
-import { removeArticles } from "modules/function";
 import { useArticleStore } from "store/articles";
 
 export default function Scrap() {
-  // let articles = JSON.parse(localStorage.getItem("articleList"));
   const { articleList } = useArticleStore();
-
   const isEmpty = articleList.length === 0;
 
   return (
     <S.Container $isEmpty={isEmpty}>
       {!isEmpty ? (
         articleList?.map((data) => {
-          console.log(data.content);
           return <Card key={data.content._id} data={data.content} />;
         })
       ) : (

--- a/src/store/articles.ts
+++ b/src/store/articles.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface Article {
+  content: object;
+}
+
+interface ArticleStore {
+  articleList: Article[];
+  idList: string[];
+  addArticle: (val: object) => void;
+  removeArticle: (id: string) => void;
+}
+
+export const useArticleStore = create<ArticleStore>()(
+  persist(
+    (set) => ({
+      articleList: [],
+      idList: [],
+      addArticle: (val) => {
+        set((prev) => ({
+          articleList: [...prev.articleList, { content: val }],
+        }));
+      },
+      removeArticle: (id) =>
+        set((prev) => ({
+          articleList: prev.articleList.filter(
+            (e: any) => e.content._id !== id
+          ),
+        })),
+    }),
+    {
+      name: "article-storage",
+    }
+  )
+);

--- a/src/store/articles.ts
+++ b/src/store/articles.ts
@@ -7,7 +7,7 @@ interface Article {
 
 interface ArticleStore {
   articleList: Article[];
-  idList: string[];
+  idList: any[];
   addArticle: (val: object) => void;
   removeArticle: (id: string) => void;
 }
@@ -20,6 +20,7 @@ export const useArticleStore = create<ArticleStore>()(
       addArticle: (val) => {
         set((prev) => ({
           articleList: [...prev.articleList, { content: val }],
+          idList: [...prev.idList, val._id],
         }));
       },
       removeArticle: (id) =>
@@ -27,6 +28,7 @@ export const useArticleStore = create<ArticleStore>()(
           articleList: prev.articleList.filter(
             (e: any) => e.content._id !== id
           ),
+          idList: prev.idList.filter((e: string) => e !== id),
         })),
     }),
     {

--- a/src/store/articles.ts
+++ b/src/store/articles.ts
@@ -22,14 +22,17 @@ export const useArticleStore = create<ArticleStore>()(
           articleList: [...prev.articleList, { content: val }],
           idList: [...prev.idList, val._id],
         }));
+        alert("기사를 스크랩했습니다.");
       },
-      removeArticle: (id) =>
+      removeArticle: (id) => {
         set((prev) => ({
           articleList: prev.articleList.filter(
             (e: any) => e.content._id !== id
           ),
           idList: prev.idList.filter((e: string) => e !== id),
-        })),
+        }));
+        alert("기사를 삭제 했습니다.");
+      },
     }),
     {
       name: "article-storage",


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- main 페이지에서 별 아이콘 클릭 시 기사 저장
- main 및 scrap 페이지에서 별 아이콘 재 클릭 시 저장된 기사 삭제
- 저장된 기사를 scrap 페이지에서 노출
- 저장된 기사가 없을 경우 안내문구와 함께 main 페이지로 이동하는 버튼 노출
- 기사 추가 삭제 시 시스템 alert 창 노출

## 2. 작업한 결과물
![meraki_기사 스크랩](https://github.com/hjyang369/assignment-front/assets/125977702/a225058d-cf0d-4181-b61b-dce8b15ee6c1)

## 3. 해당 작업을 하면서 생겼던 이슈사항
기사를 localstorage에 직접 저장하고 불러오고 있었는데 코드가 길어짐과 동시에 같은 코드를 여러번 반복해야하는 부분이 생기면서 복잡해짐.
module로 함수를 뺐지만 여전히 복잡함과 동시에 기사를 삭제했을 때 리렌더링이 일어나지 않아서 새로운 배열이 적용되지 않아 삭제한 기사가 사라지지 않음. useeffect를 사용해 값이 변경 될 때 리렌더링이 되도록 원했는데 변경되는 값을 계속 참조해 무한 렌더링이 일어남. 이때 justand를 이용해 미들웨어에 있는 persist를 사용하면 값이 바뀔 때 리렌더링이 일어날 수 있을 것이라고 판단해 스크랩된 기사가 있는 배열과 추가, 삭제에 사용되는 배열들을 justand store로 옮겨 작업함. 코드가 훨씬 간단해졌으며 localstorage에 저장된 배열이 변경될 경우 변경된 배열로 반영 해줘 기사를 삭제하면 기사가 사라졌음

## 4. 해당 작업을 통해 알게 된 내용
-justand 사용법
   - set함수
   - store
   - persist